### PR TITLE
Update frontend for structured JTBD personas and individual CRUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,14 @@ const App: React.FC = () => {
               }
             />
             <Route
+              path="/brands/:brandId/feedback-review/primary-persona"
+              element={
+                <AuthGuard>
+                  <FeedbackReviewFlowContainer />
+                </AuthGuard>
+              }
+            />
+            <Route
               path="/brands/:brandId/feedback-review/archetype"
               element={
                 <AuthGuard>

--- a/src/components/FeedbackReview/FeedbackReviewFlowContainer.tsx
+++ b/src/components/FeedbackReview/FeedbackReviewFlowContainer.tsx
@@ -4,10 +4,12 @@ import { brands } from "../../lib/api";
 import ArchetypeAdjustmentContainer from "./ArchetypeAdjustmentContainer";
 import JTBDAdjustmentContainer from "./JTBDAdjustmentContainer";
 import SummaryAdjustmentContainer from "./SummaryAdjustmentContainer";
+import PrimaryPersonaContainer from "../PrimaryPersona/PrimaryPersonaContainer";
 import {
   BrandStatus,
   BRAND_STATUS_FEEDBACK_REVIEW_SUMMARY,
   BRAND_STATUS_FEEDBACK_REVIEW_JTBD,
+  BRAND_STATUS_PRIMARY_PERSONA_SELECTION,
   BRAND_STATUS_FEEDBACK_REVIEW_ARCHETYPE,
   BRAND_STATUS_PICK_NAME,
 } from "../../lib/navigation";
@@ -36,6 +38,12 @@ const REVIEW_STEPS: ReviewStep[] = [
     component: JTBDAdjustmentContainer,
     title: "Review Jobs-to-be-Done",
     status: BRAND_STATUS_FEEDBACK_REVIEW_JTBD,
+  },
+  {
+    id: "primary-persona",
+    component: PrimaryPersonaContainer,
+    title: "Select Primary Persona",
+    status: BRAND_STATUS_PRIMARY_PERSONA_SELECTION,
   },
   {
     id: "archetype",
@@ -90,6 +98,7 @@ const FeedbackReviewFlowContainer: React.FC = () => {
     const getStepFromPath = () => {
       if (location.pathname.endsWith("/summary")) return "summary";
       if (location.pathname.endsWith("/jtbd")) return "jtbd";
+      if (location.pathname.endsWith("/primary-persona")) return "primary-persona";
       if (location.pathname.endsWith("/archetype")) return "archetype";
       if (location.pathname.endsWith("/feedback-review")) return null; // Old generic path
       return null;
@@ -219,6 +228,7 @@ const FeedbackReviewFlowContainer: React.FC = () => {
   const getStepFromPath = () => {
     if (location.pathname.endsWith("/summary")) return "summary";
     if (location.pathname.endsWith("/jtbd")) return "jtbd";
+    if (location.pathname.endsWith("/primary-persona")) return "primary-persona";
     if (location.pathname.endsWith("/archetype")) return "archetype";
     return null;
   };

--- a/src/components/FeedbackReview/JTBDAdjustmentContainer.tsx
+++ b/src/components/FeedbackReview/JTBDAdjustmentContainer.tsx
@@ -652,7 +652,7 @@ const JTBDAdjustmentContainer: React.FC<JTBDAdjustmentContainerProps> = ({
 
         if (isNew && choice === "include") {
           // Create new persona
-          await brands.createJTBDPersona(brandId, newPersona.id, toJTBDPersonaIn(newPersona));
+          await brands.createJTBDPersona(brandId, toJTBDPersonaIn(newPersona));
         } else if (!isNew && choice === "adjusted") {
           // Update existing persona with new version
           await brands.updateJTBDPersona(brandId, newPersona.id, toJTBDPersonaIn(newPersona));

--- a/src/components/PrimaryPersona/PrimaryPersonaContainer.tsx
+++ b/src/components/PrimaryPersona/PrimaryPersonaContainer.tsx
@@ -1,0 +1,436 @@
+import { Edit2, Loader, RefreshCw } from "lucide-react";
+import React, { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
+import { brands } from "../../lib/api";
+import { scrollToTop } from "../../lib/utils";
+import { JTBD, JTBDPersonaIn, PersonaInfo } from "../../types";
+import Button from "../common/Button";
+import GetHelpButton from "../common/GetHelpButton";
+import HistoryButton from "../common/HistoryButton";
+import ReactMarkdown from "react-markdown";
+import BrandicianLoader from "../common/BrandicianLoader";
+import BrandNameDisplay from "../BrandName/BrandNameDisplay";
+import { useBrandStore } from "../../store/brand";
+
+const PERSONA_INFO_LABELS: Record<string, string> = {
+  narrative: "Narrative",
+  demographics: "Demographics",
+  psychographics: "Psychographics",
+  jobs_to_be_done: "Jobs to be Done",
+  context_triggers: "Context & Triggers",
+  desired_outcomes: "Desired Outcomes",
+  current_struggles: "Current Struggles",
+  connection_to_brand: "Connection to Brand",
+};
+
+function toJTBDPersonaIn(persona: JTBD): JTBDPersonaIn {
+  return {
+    name: persona.name,
+    info: persona.info,
+    ranking: persona.ranking,
+    survey_prevalence: persona.survey_prevalence,
+    confidence: persona.confidence,
+  };
+}
+
+interface PrimaryPersonaContainerProps {
+  onComplete: () => void;
+  onError: (error: string) => void;
+}
+
+const PrimaryPersonaContainer: React.FC<PrimaryPersonaContainerProps> = ({
+  onComplete,
+  onError,
+}) => {
+  const { brandId } = useParams<{ brandId: string }>();
+  const { currentBrand } = useBrandStore();
+  const [persona, setPersona] = useState<JTBD | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingPersona, setEditingPersona] = useState<JTBD | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const hasLoadedRef = useRef(false);
+
+  useEffect(() => {
+    const generatePersona = async () => {
+      if (!brandId || hasLoadedRef.current) return;
+      hasLoadedRef.current = true;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await brands.generatePrimaryPersona(brandId);
+        setPersona(data);
+      } catch (err: any) {
+        console.error("Failed to generate primary persona:", err);
+        const errorMessage =
+          err?.response?.data?.message ||
+          err?.response?.data?.detail ||
+          "Failed to generate primary persona. Please try again.";
+        setError(errorMessage);
+        onError(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    generatePersona();
+  }, [brandId, onError]);
+
+  const handleRegenerate = async () => {
+    if (!brandId || isRegenerating) return;
+    setIsRegenerating(true);
+    setError(null);
+    setIsEditing(false);
+    setEditingPersona(null);
+    try {
+      const data = await brands.generatePrimaryPersona(brandId);
+      setPersona(data);
+    } catch (err: any) {
+      console.error("Failed to regenerate primary persona:", err);
+      const errorMessage =
+        err?.response?.data?.message ||
+        "Failed to regenerate primary persona. Please try again.";
+      setError(errorMessage);
+    } finally {
+      setIsRegenerating(false);
+    }
+    scrollToTop();
+  };
+
+  const handleSave = async () => {
+    if (!brandId || !persona) return;
+    setIsSaving(true);
+    try {
+      const personaToSave = isEditing && editingPersona ? editingPersona : persona;
+      await brands.savePrimaryPersona(brandId, toJTBDPersonaIn(personaToSave));
+      setIsEditing(false);
+      setEditingPersona(null);
+      onComplete();
+    } catch (err: any) {
+      console.error("Failed to save primary persona:", err);
+      const errorMessage =
+        err?.response?.data?.message ||
+        "Failed to save primary persona. Please try again.";
+      setError(errorMessage);
+      onError(errorMessage);
+    } finally {
+      setIsSaving(false);
+    }
+    scrollToTop();
+  };
+
+  const handleSkip = () => {
+    onComplete();
+    scrollToTop();
+  };
+
+  const handleStartEditing = () => {
+    setEditingPersona(persona ? { ...persona } : null);
+    setIsEditing(true);
+  };
+
+  const handleCancelEditing = () => {
+    setEditingPersona(null);
+    setIsEditing(false);
+  };
+
+  const handleSaveEdits = () => {
+    if (editingPersona) {
+      setPersona(editingPersona);
+    }
+    setIsEditing(false);
+    setEditingPersona(null);
+  };
+
+  const handleEditInfoField = (field: keyof PersonaInfo, value: string) => {
+    if (!editingPersona) return;
+    setEditingPersona({
+      ...editingPersona,
+      info: {
+        ...editingPersona.info,
+        [field]: value,
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="loader-container">
+        <div className="flex flex-col items-center gap-2">
+          <BrandicianLoader />
+          <p className="text-gray-600">
+            Generating your primary persona...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !persona) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-neutral-50 to-neutral-100">
+        <div className="bg-white rounded-lg shadow-lg p-8 max-w-md w-full text-center">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">
+            Generation Failed
+          </h2>
+          <p className="text-red-600 mb-6">{error}</p>
+          <div className="flex justify-center gap-3">
+            <Button
+              onClick={() => {
+                hasLoadedRef.current = false;
+                setError(null);
+                setIsLoading(true);
+                // Trigger re-load
+                const loadAgain = async () => {
+                  try {
+                    const data = await brands.generatePrimaryPersona(brandId!);
+                    setPersona(data);
+                  } catch (err: any) {
+                    setError(err?.response?.data?.message || "Failed to generate primary persona.");
+                  } finally {
+                    setIsLoading(false);
+                  }
+                };
+                loadAgain();
+              }}
+              size="md"
+            >
+              Try Again
+            </Button>
+            <Button onClick={handleSkip} variant="secondary" size="md">
+              Skip
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!persona) {
+    return null;
+  }
+
+  const displayPersona = isEditing && editingPersona ? editingPersona : persona;
+
+  const renderPersonaInfoDisplay = (info: PersonaInfo | undefined) => {
+    if (!info) return <p className="text-gray-400 italic">No details available</p>;
+
+    const fields = Object.entries(PERSONA_INFO_LABELS).filter(([key]) => {
+      const val = info[key as keyof PersonaInfo];
+      return typeof val === "string" && val.trim().length > 0;
+    });
+
+    if (fields.length === 0) return <p className="text-gray-400 italic">No details available</p>;
+
+    return fields.map(([key, label]) => (
+      <div key={key} className="mb-4 last:mb-0">
+        <h4 className="text-sm font-semibold text-neutral-500 uppercase tracking-wide mb-1">
+          {label}
+        </h4>
+        <div className="prose prose-sm max-w-none text-neutral-700">
+          <ReactMarkdown>{info[key as keyof PersonaInfo] as string}</ReactMarkdown>
+        </div>
+      </div>
+    ));
+  };
+
+  const renderEditForm = () => {
+    if (!editingPersona) return null;
+
+    const fields = Object.entries(PERSONA_INFO_LABELS).filter(([key]) => {
+      const val = editingPersona.info?.[key as keyof PersonaInfo];
+      return typeof val === "string" && val.trim().length > 0;
+    });
+
+    return (
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-neutral-700 mb-1">
+            Persona Name
+          </label>
+          <input
+            type="text"
+            value={editingPersona.name}
+            onChange={(e) =>
+              setEditingPersona({ ...editingPersona, name: e.target.value })
+            }
+            className="w-full p-2 border border-neutral-300 rounded-md"
+          />
+        </div>
+
+        {fields.length > 0 ? (
+          fields.map(([key, label]) => (
+            <div key={key}>
+              <label className="block text-sm font-medium text-neutral-700 mb-1">
+                {label}
+              </label>
+              <textarea
+                value={(editingPersona.info?.[key as keyof PersonaInfo] as string) || ""}
+                onChange={(e) => handleEditInfoField(key as keyof PersonaInfo, e.target.value)}
+                className="w-full min-h-[100px] p-2 border border-neutral-300 rounded-md"
+              />
+            </div>
+          ))
+        ) : editingPersona.description !== undefined ? (
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">
+              Description
+            </label>
+            <textarea
+              value={editingPersona.description || ""}
+              onChange={(e) =>
+                setEditingPersona({ ...editingPersona, description: e.target.value })
+              }
+              className="w-full min-h-[150px] p-2 border border-neutral-300 rounded-md"
+            />
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" onClick={handleCancelEditing} variant="ghost" size="md">
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSaveEdits} size="md">
+            Apply Changes
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-neutral-50 to-neutral-100 py-8">
+      <div className="container mx-auto px-4">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex justify-between flex-wrap gap-3 items-center mb-6">
+            <h1 className="text-3xl font-display font-bold text-neutral-800">
+              <BrandNameDisplay brand={currentBrand!} />
+              Primary Persona
+            </h1>
+            <div className="flex items-center flex-wrap gap-3">
+              {brandId && (
+                <HistoryButton brandId={brandId} variant="outline" size="md" />
+              )}
+              <GetHelpButton variant="secondary" size="md" />
+            </div>
+          </div>
+
+          <p className="text-neutral-600 mb-6">
+            Based on your JTBD personas and survey feedback, we've generated a primary
+            persona that represents your most important target customer. Review and
+            edit as needed, then accept to continue.
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="bg-white rounded-lg shadow-lg p-4 sm:p-6 mb-6">
+            {/* Persona header */}
+            <div className="flex justify-between items-start mb-4">
+              <div>
+                <h2 className="text-xl font-bold text-neutral-800">
+                  {displayPersona.name}
+                </h2>
+                {/* Metadata badges */}
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {displayPersona.confidence && (
+                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${
+                      displayPersona.confidence === "HIGH" ? "bg-green-100 text-green-800" :
+                      displayPersona.confidence === "MEDIUM" ? "bg-yellow-100 text-yellow-800" :
+                      "bg-red-100 text-red-800"
+                    }`}>
+                      Confidence: {displayPersona.confidence}
+                    </span>
+                  )}
+                  {displayPersona.survey_prevalence !== undefined && (
+                    <span className="px-2 py-1 rounded-full bg-blue-100 text-blue-800 text-xs font-medium">
+                      Survey Prevalence: {displayPersona.survey_prevalence}%
+                    </span>
+                  )}
+                  {displayPersona.ranking !== undefined && (
+                    <span className="px-2 py-1 rounded-full bg-purple-100 text-purple-800 text-xs font-medium">
+                      Ranking: {displayPersona.ranking}/5
+                    </span>
+                  )}
+                </div>
+              </div>
+              {!isEditing && (
+                <button
+                  onClick={handleStartEditing}
+                  className="text-neutral-400 hover:text-primary-600 transition-colors"
+                  title="Edit persona"
+                >
+                  <Edit2 className="h-5 w-5" />
+                </button>
+              )}
+            </div>
+
+            {/* Persona content */}
+            {isEditing ? (
+              renderEditForm()
+            ) : (
+              <div className="mt-4">
+                {displayPersona.info ? (
+                  renderPersonaInfoDisplay(displayPersona.info)
+                ) : displayPersona.description ? (
+                  <div className="prose prose-sm max-w-none text-neutral-700">
+                    <ReactMarkdown>{displayPersona.description}</ReactMarkdown>
+                  </div>
+                ) : (
+                  <p className="text-neutral-400 italic">No details available</p>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-wrap justify-between items-center gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={handleRegenerate}
+              disabled={isRegenerating || isSaving}
+            >
+              {isRegenerating ? (
+                <Loader className="animate-spin h-5 w-5 mr-2 inline" />
+              ) : (
+                <RefreshCw className="h-5 w-5 mr-2 inline" />
+              )}
+              Regenerate
+            </Button>
+
+            <div className="flex flex-wrap gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                size="md"
+                onClick={handleSkip}
+                disabled={isSaving}
+              >
+                Skip
+              </Button>
+              <Button
+                type="button"
+                size="lg"
+                onClick={handleSave}
+                disabled={isSaving || isEditing}
+              >
+                {isSaving && (
+                  <Loader className="animate-spin h-5 w-5 mr-2 inline" />
+                )}
+                Accept & Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PrimaryPersonaContainer;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { BrandStatus } from "./navigation";
-import { JTBDList, Survey, SubmissionLink, AdjustObject, JTBD, JTBDPersonaIn, JTBDPersonaAdjustment } from "../types";
+import { JTBDList, SuggestedJTBDList, Survey, SubmissionLink, AdjustObject, JTBD, JTBDPersonaIn, JTBDPersonaAdjustment } from "../types";
 import { config } from "../config";
 
 // Extend axios config to include our metadata
@@ -393,38 +393,13 @@ export const brands = {
     await api.delete(apiPath(`/brands/${brandId}/answers/${answerId}`));
   },
 
-  getJTBD: async (brandId: string) => {
+  getJTBD: async (brandId: string): Promise<JTBDList | null> => {
     try {
-      console.log("Attempting to get JTBD for brand:", brandId);
-      // Try to get existing JTBD first
       const response = await api.get(apiPath(`/brands/${brandId}/jtbd/`));
-      console.log("Successfully retrieved existing JTBD:", response.data);
-      return response.data;
+      return response.data as JTBDList;
     } catch (error: any) {
-      console.log(
-        "JTBD GET failed:",
-        error.response?.status,
-        error.response?.data
-      );
       if (error.response?.status === 404) {
-        console.log("No JTBD exists, attempting to generate new one...");
-        // If no JTBD exists, suggest new one
-        const key = createRequestKey(
-          "POST",
-          apiPath(`/brands/${brandId}/jtbd/`)
-        );
-        return deduplicate(key, async () => {
-          try {
-            const response = await api.post(
-              apiPath(`/brands/${brandId}/jtbd/`)
-            );
-            console.log("Successfully generated new JTBD:", response.data);
-            return response.data;
-          } catch (postError: any) {
-            console.error("Failed to generate JTBD:", postError.response?.data);
-            throw postError;
-          }
-        });
+        return null;
       }
       throw error;
     }
@@ -438,8 +413,8 @@ export const brands = {
     await api.put(apiPath(`/brands/${brandId}/jtbd/${personaId}/`), persona);
   },
 
-  createJTBDPersona: async (brandId: string, personaId: string, persona: JTBDPersonaIn): Promise<JTBD> => {
-    const response = await api.post(apiPath(`/brands/${brandId}/jtbd/${personaId}/`), persona);
+  createJTBDPersona: async (brandId: string, persona: JTBDPersonaIn): Promise<JTBD> => {
+    const response = await api.post(apiPath(`/brands/${brandId}/jtbd/persona/`), persona);
     return response.data;
   },
 
@@ -666,9 +641,9 @@ export const brands = {
     return response.data;
   },
 
-  suggestJTBD: async (brandId: string) => {
+  suggestJTBD: async (brandId: string): Promise<SuggestedJTBDList> => {
     const response = await api.post(apiPath(`/brands/${brandId}/jtbd`));
-    return response.data;
+    return response.data as SuggestedJTBDList;
   },
 
   getArchetype: async (brandId: string) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { BrandStatus } from "./navigation";
-import { JTBDList, Survey, SubmissionLink, AdjustObject } from "../types";
+import { JTBDList, Survey, SubmissionLink, AdjustObject, JTBD, JTBDPersonaIn, JTBDPersonaAdjustment } from "../types";
 import { config } from "../config";
 
 // Extend axios config to include our metadata
@@ -434,7 +434,46 @@ export const brands = {
     await api.put(apiPath(`/brands/${brandId}/jtbd/`), jtbd);
   },
 
-  adjustJTBDPersonas: async (brandId: string): Promise<AdjustObject[]> => {
+  updateJTBDPersona: async (brandId: string, personaId: string, persona: JTBDPersonaIn): Promise<void> => {
+    await api.put(apiPath(`/brands/${brandId}/jtbd/${personaId}/`), persona);
+  },
+
+  createJTBDPersona: async (brandId: string, personaId: string, persona: JTBDPersonaIn): Promise<JTBD> => {
+    const response = await api.post(apiPath(`/brands/${brandId}/jtbd/${personaId}/`), persona);
+    return response.data;
+  },
+
+  deleteJTBDPersona: async (brandId: string, personaId: string): Promise<void> => {
+    await api.delete(apiPath(`/brands/${brandId}/jtbd/${personaId}/`));
+  },
+
+  getJTBDDrivers: async (brandId: string): Promise<string> => {
+    const response = await api.get(apiPath(`/brands/${brandId}/jtbd-drivers/`));
+    return response.data.drivers;
+  },
+
+  updateJTBDDrivers: async (brandId: string, drivers: string): Promise<void> => {
+    await api.put(apiPath(`/brands/${brandId}/jtbd-drivers/`), { drivers });
+  },
+
+  getPrimaryPersona: async (brandId: string): Promise<JTBD> => {
+    const response = await api.get(apiPath(`/brands/${brandId}/primary-persona/`));
+    return response.data;
+  },
+
+  generatePrimaryPersona: async (brandId: string): Promise<JTBD> => {
+    const key = createRequestKey("POST", apiPath(`/brands/${brandId}/primary-persona/`));
+    return deduplicate(key, async () => {
+      const response = await api.post(apiPath(`/brands/${brandId}/primary-persona/`));
+      return response.data;
+    });
+  },
+
+  savePrimaryPersona: async (brandId: string, persona: JTBDPersonaIn): Promise<void> => {
+    await api.put(apiPath(`/brands/${brandId}/primary-persona/`), persona);
+  },
+
+  adjustJTBDPersonas: async (brandId: string): Promise<JTBDPersonaAdjustment[]> => {
     const key = createRequestKey(
       "POST",
       apiPath(`/brands/${brandId}/adjust/jtbd-personas`)

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -8,6 +8,7 @@ export type BrandStatus =
   | "collect_feedback"
   | "feedback_review_summary"
   | "feedback_review_jtbd"
+  | "primary_persona_selection"
   | "feedback_review_archetype"
   | "pick_name"
   | "create_visual_identity"
@@ -26,6 +27,8 @@ export const BRAND_STATUS_CREATE_SURVEY = "create_survey";
 export const BRAND_STATUS_COLLECT_FEEDBACK = "collect_feedback";
 export const BRAND_STATUS_FEEDBACK_REVIEW_SUMMARY = "feedback_review_summary";
 export const BRAND_STATUS_FEEDBACK_REVIEW_JTBD = "feedback_review_jtbd";
+export const BRAND_STATUS_PRIMARY_PERSONA_SELECTION =
+  "primary_persona_selection";
 export const BRAND_STATUS_FEEDBACK_REVIEW_ARCHETYPE =
   "feedback_review_archetype";
 export const BRAND_STATUS_PICK_NAME = "pick_name";
@@ -50,6 +53,7 @@ export const getRouteForStatus = (
     collect_feedback: `/brands/${brandId}/collect-feedback`,
     feedback_review_summary: `/brands/${brandId}/feedback-review/summary`,
     feedback_review_jtbd: `/brands/${brandId}/feedback-review/jtbd`,
+    primary_persona_selection: `/brands/${brandId}/feedback-review/primary-persona`,
     feedback_review_archetype: `/brands/${brandId}/feedback-review/archetype`,
     pick_name: `/brands/${brandId}/pick-name`,
     create_visual_identity: `/brands/${brandId}/create-visual-identity`,

--- a/src/store/brand.ts
+++ b/src/store/brand.ts
@@ -246,7 +246,7 @@ export const useBrandStore = create<BrandState>((set) => ({
         currentBrand: state.currentBrand
           ? {
               ...state.currentBrand,
-              jtbd: jtbdData,
+              jtbd: jtbdData ?? undefined,
             }
           : null,
         isLoading: false,

--- a/src/store/brand.ts
+++ b/src/store/brand.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { brands } from "../lib/api";
-import { Brand, Question, Answer, JTBDList } from "../types";
+import { Brand, Question, Answer, JTBDList, JTBDPersonaIn } from "../types";
 import { BrandStatus } from "../lib/navigation";
 import { AxiosInstance } from "axios";
 
@@ -57,6 +57,7 @@ interface BrandState {
   progressBrandStatus: (brandId: string) => Promise<{ status: BrandStatus }>;
   loadJTBD: (brandId: string) => Promise<void>;
   updateJTBD: (brandId: string, jtbd: JTBDList) => Promise<void>;
+  updateJTBDPersona: (brandId: string, personaId: string, persona: JTBDPersonaIn) => Promise<void>;
   generateBrandSummary: (brandId: string) => Promise<void>;
   updateBrandSummary: (brandId: string, summary: string) => Promise<void>;
   loadSummary: (brandId: string) => Promise<string>;
@@ -280,6 +281,28 @@ export const useBrandStore = create<BrandState>((set) => ({
       set({ isLoading: false, error: "Failed to update JTBD" });
       throw error;
     }
+  },
+
+  updateJTBDPersona: async (brandId: string, personaId: string, persona: JTBDPersonaIn) => {
+    await brands.updateJTBDPersona(brandId, personaId, persona);
+    set((state) => ({
+      currentBrand: state.currentBrand && state.currentBrand.jtbd
+        ? {
+            ...state.currentBrand,
+            jtbd: {
+              ...state.currentBrand.jtbd,
+              personas: {
+                ...state.currentBrand.jtbd.personas,
+                [personaId]: {
+                  ...state.currentBrand.jtbd.personas[personaId],
+                  ...persona,
+                  id: personaId,
+                },
+              },
+            },
+          }
+        : state.currentBrand,
+    }));
   },
 
   generateBrandSummary: async (brandId: string) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,6 +96,14 @@ export interface PersonaInfo {
 
 export type ConfidenceLevel = "LOW" | "MEDIUM" | "HIGH";
 
+/** Suggested persona from the suggest endpoint — no id or server-controlled fields */
+export interface SuggestedPersona {
+  name: string;
+  description?: string;
+  info?: PersonaInfo;
+}
+
+/** Full persisted persona with mandatory id */
 export interface JTBD {
   id: string;
   name: string;
@@ -119,6 +127,12 @@ export type JTBDPersonaAdjustment = [JTBD | null, JTBD];
 
 export interface JTBDList {
   personas: Record<string, JTBD>;
+  drivers?: string;
+}
+
+/** Suggested JTBD list from suggest endpoint — personas have no ids */
+export interface SuggestedJTBDList {
+  personas: SuggestedPersona[];
   drivers?: string;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,13 +82,40 @@ export type BrandAssetType =
   | "visual_style"
   | "ext_system_asset";
 
+export interface PersonaInfo {
+  narrative?: string;
+  demographics?: string;
+  psychographics?: string;
+  jobs_to_be_done?: string;
+  context_triggers?: string;
+  desired_outcomes?: string;
+  current_struggles?: string;
+  connection_to_brand?: string;
+  comment?: Record<string, string>;
+}
+
+export type ConfidenceLevel = "LOW" | "MEDIUM" | "HIGH";
+
 export interface JTBD {
   id: string;
-  brand_id: string;
   name: string;
-  description: string;
+  description?: string;
+  info?: PersonaInfo;
+  ranking?: number;
+  survey_prevalence?: number;
+  confidence?: ConfidenceLevel;
   importance?: JTBDImportance;
 }
+
+export interface JTBDPersonaIn {
+  name: string;
+  info?: PersonaInfo;
+  ranking?: number;
+  survey_prevalence?: number;
+  confidence?: ConfidenceLevel;
+}
+
+export type JTBDPersonaAdjustment = [JTBD | null, JTBD];
 
 export interface JTBDList {
   personas: Record<string, JTBD>;


### PR DESCRIPTION
- Add PersonaInfo, ConfidenceLevel, JTBDPersonaIn types
- Add individual persona CRUD + drivers + primary persona API methods
- Update JTBDContainer to use individual POST per persona and PUT drivers
- Update JTBDAdjustmentContainer for [old|null, new] tuple format with structured PersonaInfo display, N/A filtering, remove persona option
- Add PrimaryPersonaContainer for primary persona selection step
- Add primary_persona_selection status and route in navigation/App
- Update FeedbackReviewFlowContainer with primary-persona step

Compatible with backend commit 093a6b2 (brandician-back develop)